### PR TITLE
Remove app-network, use host.docker.internal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,4 @@ MAIL_FROM="samarkin20022002@gmail.com"
 MAIL_PORT=587
 
 RMQ_QUEUE="notifications-queue"
-RMQ_URL="amqp://localhost:5672"
+RMQ_URL="amqp://default_user:default_password@localhost:5672"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,8 @@ services:
     image: samarkinivan/notifications-service:latest
     container_name: notifications-service
     restart: on-failure
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       APP_PORT: 8084
       MAIL_HOST: 'smtp.gmail.com'
@@ -11,12 +13,6 @@ services:
       MAIL_FROM: 'samarkin20022002@gmail.com'
       MAIL_PORT: 587
       RMQ_QUEUE: 'notifications-queue'
-      RMQ_URL: 'amqp://default_user:default_password@rabbitmq:5672'
+      RMQ_URL: 'amqp://default_user:default_password@host.docker.internal:5672'
     ports:
       - '8084:8084'
-    networks:
-      - app-network
-
-networks:
-  app-network:
-    external: true


### PR DESCRIPTION
Remove external `app-network` dependency. RabbitMQ URL updated to use `host.docker.internal`.